### PR TITLE
Migrate the running tests to JUnit 4

### DIFF
--- a/org.eclipse.wb.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.tests/META-INF/MANIFEST.MF
@@ -41,7 +41,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.wb.core.xml,
  org.eclipse.wb.xwt,
  org.eclipse.wb.rcp.databinding.xwt,
- org.junit;bundle-version="4.12.0"
+ org.junit;bundle-version="4.12.0",
+ org.junit.jupiter.api;bundle-version="5.8.1"
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: 
  lib/org.assertj_1.7.1.v20170413-2026.jar,

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/WindowBuilderTests.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/WindowBuilderTests.java
@@ -19,27 +19,28 @@ import org.eclipse.wb.tests.designer.swing.SwingTests;
 import org.eclipse.wb.tests.designer.swt.SwtTests;
 import org.eclipse.wb.tests.utils.CommonTests;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
 
 /**
  * All WindowBuilder tests.
  *
  * @author scheglov_ke
  */
-public class WindowBuilderTests extends TestCase {
-  public static Test suite() {
-    TestSuite suite = new TestSuite("org.eclipse.wb");
-    suite.addTest(CommonTests.suite());
-    suite.addTest(CoreTests.suite());
-    suite.addTest(SwingTests.suite());
-    suite.addTest(SwtTests.suite());
-    suite.addTest(RcpTests.suite());
-    suite.addTest(XmlTests.suite());
-    suite.addTest(XwtTests.suite());
-    suite.addTest(EditorTests.suite());
-    //suite.addTestSuite(WaitForMemoryProfilerTest.class);
-    return suite;
-  }
+
+@RunWith(Suite.class)
+@SuiteClasses({
+    CommonTests.class,
+    CoreTests.class,
+    SwingTests.class,
+    SwtTests.class,
+    RcpTests.class,
+    XmlTests.class,
+    XwtTests.class,
+    EditorTests.class,
+
+})
+
+public class WindowBuilderTests {
 }

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/editor/EditorTests.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/editor/EditorTests.java
@@ -10,31 +10,25 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.editor;
 
-import org.eclipse.wb.tests.designer.core.DesignerSuiteTests;
-import org.eclipse.wb.tests.designer.editor.action.ActionTests;
-import org.eclipse.wb.tests.designer.editor.validator.LayoutRequestValidatorTests;
-
-import junit.framework.Test;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
 
 /**
  * @author scheglov_ke
  */
-public class EditorTests extends DesignerSuiteTests {
-  public static Test suite() {
-    TestSuite suite = new TestSuite("org.eclipse.wb.editor");
-    // basic policy
-    suite.addTest(createSingleSuite(TopSelectionEditPolicyTest.class));
+@RunWith(Suite.class)
+@SuiteClasses({
+    //basic policy
+    TopSelectionEditPolicyTest.class,
     // basic features
-    suite.addTest(createSingleSuite(UndoManagerTest.class));
-    suite.addTest(createSingleSuite(ContentDescriberTest.class));
-    suite.addTest(createSingleSuite(ReparseOnModificationTest.class));
-    suite.addTest(createSingleSuite(SelectSupportTest.class));
-    suite.addTest(createSingleSuite(ComponentsPropertiesPageTest.class));
-    suite.addTest(createSingleSuite(JavaPropertiesToolBarContributorTest.class));
-    // suites
-    suite.addTest(ActionTests.suite());
-    suite.addTest(LayoutRequestValidatorTests.suite());
-    return suite;
-  }
+    UndoManagerTest.class,
+    ContentDescriberTest.class,
+    ReparseOnModificationTest.class,
+    SelectSupportTest.class,
+    ComponentsPropertiesPageTest.class,
+    JavaPropertiesToolBarContributorTest.class
+})
+
+public class EditorTests {
 }

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/utils/CommonTests.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/utils/CommonTests.java
@@ -10,21 +10,19 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.utils;
 
-import org.eclipse.wb.tests.designer.core.DesignerSuiteTests;
-
-import junit.framework.Test;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
 
 /**
  * Test for "org.eclipse.wb.core.temp" project.
  *
  * @author scheglov_ke
  */
-public class CommonTests extends DesignerSuiteTests {
-  public static Test suite() {
-    TestSuite suite = new TestSuite("org.eclipse.wb.core.TEMP");
-    suite.addTestSuite(StringUtilitiesTest.class);
-    suite.addTest(createSingleSuite(ProjectClassLoaderTest.class));
-    return suite;
-  }
+@RunWith(Suite.class)
+@SuiteClasses({
+    StringUtilitiesTest.class,
+    ProjectClassLoaderTest.class})
+
+public class CommonTests {
 }


### PR DESCRIPTION
JUnit 4 allows to run Junit3 tests and these days it seems easier to
manage test suites using Junit4 then to remember how Junit3 handled
that.